### PR TITLE
add feature for sort-by and order including error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -204,20 +204,16 @@ describe("PATCH /api/articles/:article_id", () => {
 });
 
 describe("GET /api/articles?topic=:topic", () => {
-  test("return status 200 when successful with no query", () => {
+  test("200: returns an object with the expected article values when not given a query", () => {
     return request(app)
       .get("/api/articles")
-      .expect(200);
-  });
-  test("return an object with the expected article values with not given a query", () => {
-    return request(app)
-      .get("/api/articles")
+      .expect(200)
       .then(response => {
         const {
           body: { articles }
         } = response;
         expect(articles).toHaveLength(12);
-        expect(articles).toBeSortedBy("created_at");
+        expect(articles).toBeSortedBy("created_at", { descending: true });
         articles.forEach(article => {
           expect(article).toEqual(
             expect.objectContaining({
@@ -234,7 +230,7 @@ describe("GET /api/articles?topic=:topic", () => {
         });
       });
   });
-  test("returns an object with the expected article values when given a query", () => {
+  test("200: returns an object with the expected article values when given a topic query", () => {
     return request(app)
       .get("/api/articles?topic=mitch")
       .expect(200)
@@ -243,13 +239,65 @@ describe("GET /api/articles?topic=:topic", () => {
           body: { articles }
         } = response;
         expect(articles).toHaveLength(11);
-        expect(articles).toBeSortedBy("created_at");
+        expect(articles).toBeSortedBy("created_at", { descending: true });
         articles.forEach(article => {
           expect(article).toEqual(
             expect.objectContaining({
               article_id: expect.any(Number),
               title: expect.any(String),
               topic: "mitch",
+              author: expect.any(String),
+              body: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              comment_count: expect.any(Number)
+            })
+          );
+        });
+      });
+  });
+  test("200: returns an object with the expected article values when given a sort by query", () => {
+    return request(app)
+      .get("/api/articles?sort_by=votes")
+      .expect(200)
+      .then(response => {
+        const {
+          body: { articles }
+        } = response;
+        expect(articles).toHaveLength(12);
+        expect(articles).toBeSortedBy("votes", { descending: true });
+        articles.forEach(article => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              article_id: expect.any(Number),
+              title: expect.any(String),
+              topic: expect.any(String),
+              author: expect.any(String),
+              body: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              comment_count: expect.any(Number)
+            })
+          );
+        });
+      });
+  });
+  test("200: returns an object with the expected article values when given an order by query", () => {
+    return request(app)
+      .get("/api/articles?order=asc")
+      .expect(200)
+      .then(response => {
+        const {
+          body: { articles }
+        } = response;
+        expect(articles).toHaveLength(12);
+        expect(articles).toBeSortedBy("created_at");
+        articles.forEach(article => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              article_id: expect.any(Number),
+              title: expect.any(String),
+              topic: expect.any(String),
               author: expect.any(String),
               body: expect.any(String),
               created_at: expect.any(String),
@@ -280,6 +328,22 @@ describe("GET /api/articles?topic=:topic", () => {
         expect(body.msg).toBe(
           "You have made a bad request - this topic does not exist"
         );
+      });
+  });
+  test("400: responds with an error when passed an invalid query to sort by", () => {
+    return request(app)
+      .get("/api/articles?sort_by=not-valid")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("You have made a bad request");
+      });
+  });
+  test("400: responds with an error when passed an invalid order query", () => {
+    return request(app)
+      .get("/api/articles?order=delete")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("You have made a bad request");
       });
   });
 });

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -31,7 +31,10 @@ exports.patchArticleVotesById = (request, response, next) => {
 
 exports.getArticles = (request, response, next) => {
   const topicFilter = request.query.topic;
-  selectArticles(topicFilter)
+  let orderQuery = request.query.order;
+  let sortQuery = request.query.sort_by;
+
+  selectArticles(topicFilter, orderQuery, sortQuery)
     .then(articles => {
       response.status(200).send({ articles });
     })
@@ -42,7 +45,7 @@ exports.getArticles = (request, response, next) => {
 
 exports.getCommentsByArticleId = (request, response, next) => {
   const { article_id } = request.params;
-  
+
   selectCommentsByArticleId(article_id)
     .then(comments => {
       response.status(200).send({ comments });


### PR DESCRIPTION
I have refactored the /api/articles end point so that it can now take a query for sort-by and order. I have also refactored the query string to make the code more dry in articles-model.js. 